### PR TITLE
cranlogs links updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # cran-downloads
 
-A shiny app to visualise CRAN downloads with data from the [cranlogs](https://github.com/metacran/cranlogs) package.
+A shiny app to visualise CRAN downloads with data from the [cranlogs](http://r-hub.github.io/cranlogs/) package.
 
 Live app at <https://hadley.shinyapps.io/cran-downloads/>
 
 ## To use
 
 ```R
-# install.packages("devtools")
-devtools::install_github("metacran/cranlogs")
-devtools::install_github("rstudio/shiny")
+install.packages("cranlogs")
+install.packages("shiny")
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cran-downloads
 
-A shiny app to visualise CRAN downloads with data from the [cranlogs](http://r-hub.github.io/cranlogs/) package.
+A shiny app to visualise CRAN downloads with data from the [cranlogs](https://r-hub.github.io/cranlogs/) package.
 
 Live app at <https://hadley.shinyapps.io/cran-downloads/>
 

--- a/ui.R
+++ b/ui.R
@@ -20,7 +20,7 @@ shinyUI(fluidPage(
         dblclick = "click"
       ),
       HTML(
-        "<p>Data from <a href='https://github.com/metacran/cranlogs'>cranlogs</a>.",
+        "<p>Data from <a href='http://r-hub.github.io/cranlogs/'>cranlogs</a>.",
         "Code on <a href='https://github.com/hadley/cran-downloads'>github</a>.</p>"
       )
     )

--- a/ui.R
+++ b/ui.R
@@ -20,7 +20,7 @@ shinyUI(fluidPage(
         dblclick = "click"
       ),
       HTML(
-        "<p>Data from <a href='http://r-hub.github.io/cranlogs/'>cranlogs</a>.",
+        "<p>Data from <a href='https://r-hub.github.io/cranlogs/'>cranlogs</a>.",
         "Code on <a href='https://github.com/hadley/cran-downloads'>github</a>.</p>"
       )
     )


### PR DESCRIPTION
:wave: @hadley, a small PR because `cranlogs` moved and now has a `pkgdown` website. Thank you!